### PR TITLE
changed default no code feed to 3500

### DIFF
--- a/webapp/cnc/gcode/parser.js
+++ b/webapp/cnc/gcode/parser.js
@@ -278,7 +278,7 @@ define(['libs/jsparse', 'cnc/util'], function (jp, util) {
             motionMode: moveTraverseRate,
             unitMode: mmConverter,
             planeMode: XY_PLANE,
-            feedRate: Math.min(200, maxFeedRate),
+            feedRate: Math.min(3500, maxFeedRate),
             travelFeedRate: Math.min(travelFeedRate, maxFeedRate),
             pathControl: 61,
             path: path,


### PR DESCRIPTION
when g-code reads a new line with no function, it assumes previous function and feed.
this doesn't happen here. so i set the value to 3500, a value i mostly machine.
this is a temporary fix.